### PR TITLE
remove direct import of osgeo lib

### DIFF
--- a/pyeo/raster_manipulation.py
+++ b/pyeo/raster_manipulation.py
@@ -118,12 +118,10 @@ import faulthandler
 import glob
 import logging
 import numpy as np
-import ogr
 import os
 from osgeo import gdal
 from osgeo import gdal_array, osr, ogr
 from osgeo.gdal_array import NumericTypeCodeToGDALTypeCode, GDALTypeCodeToNumericTypeCode
-import osr
 import pdb
 import re
 import shutil


### PR DESCRIPTION
This is crashing in many GDAL implementation (>2.8) and is implemented in GDAL binding since gdal>1.8 so it should work everywhere. 
Also `ogr` and `osr` are already imported using `from osgeo import osr, ogr, gdal_array`so there was a conflict anyway